### PR TITLE
Use https to download libyaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### YAML gem for [mruby](https://github.com/mruby/mruby)
 
-mruby-yaml wraps [libyaml](http://pyyaml.org/wiki/LibYAML) and therefore complies with the YAML 1.1 standard. File IO is not supported, as this would create a dependency on other mruby gems.
+mruby-yaml wraps [libyaml](https://pyyaml.org/wiki/LibYAML) and therefore complies with the YAML 1.1 standard. File IO is not supported, as this would create a dependency on other mruby gems.
 
 ### Defines
 | Name                             | Default | Description                    |

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -25,7 +25,7 @@ MRuby::Gem::Specification.new('mruby-yaml') do |spec|
   if ! File.exists? yaml_dir
     Dir.chdir(build_dir) do
       e = {}
-      run_command e, "curl http://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
+      run_command e, "curl -L https://pyyaml.org/download/libyaml/yaml-#{yaml_version}.tar.gz | tar -xzv"
       run_command e, "mkdir #{yaml_dir}/build"
     end
   end


### PR DESCRIPTION
Building mruby-yaml started to fail today.

```
GIT   https://github.com/hone/mruby-yaml.git -> build/mrbgems/mruby-yaml
Cloning into '/home/travis/build/itamae-kitchen/mitamae/mruby/build/mrbgems/mruby-yaml'...
remote: Counting objects: 8, done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 8 (delta 0), reused 7 (delta 0), pack-reused 0
Unpacking objects: 100% (8/8), done.
build: [exec] curl http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz | tar -xzv
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   178  100   178    0     0   1587      0 --:--:-- --:--:-- --:--:--  1589
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
rake aborted!
curl http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz | tar -xzv failed
```

This was because:

```
$ curl -D - http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz
HTTP/1.1 301 Moved Permanently
Server: GitHub.com
Content-Type: text/html
Location: https://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz
...
```

So I changed it to fetch libyaml using https. Also, to prevent this kind of issue automatically, I specified `-L` as well. (I didn't specify `curl -f` and use `set -o pipefail` with bash because bash might not be available)